### PR TITLE
Issue forgerock-bom#2 Moved dependency definitions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,11 +164,6 @@
 
         <!-- Forgerock binary license name -->
         <binary.license.name>Forgerock_License.txt</binary.license.name>
-
-        <!-- openam copy module version -->
-        <jato.version>2005-05-04</jato.version>
-        <authapi.version>2005-08-12</authapi.version>
-        <jdmk.version>2007-01-10</jdmk.version>
     </properties>
 
     <prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -167,8 +167,6 @@
 
         <!-- openam copy module version -->
         <jato.version>2005-05-04</jato.version>
-        <cc-ui.version>2008-08-08</cc-ui.version>
-        <log4j.version>1.2.16</log4j.version>
         <authapi.version>2005-08-12</authapi.version>
         <jdmk.version>2007-01-10</jdmk.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
  "Portions Copyrighted [year] [name of copyright owner]"
 
  Portions Copyrighted 2019 Open Source Solution Technology Corporation
+ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -163,6 +164,13 @@
 
         <!-- Forgerock binary license name -->
         <binary.license.name>Forgerock_License.txt</binary.license.name>
+
+        <!-- openam copy module version -->
+        <jato.version>2005-05-04</jato.version>
+        <cc-ui.version>2008-08-08</cc-ui.version>
+        <log4j.version>1.2.16</log4j.version>
+        <authapi.version>2005-08-12</authapi.version>
+        <jdmk.version>2007-01-10</jdmk.version>
     </properties>
 
     <prerequisites>


### PR DESCRIPTION
## Analysis
openam-jp/forgerock-bom#2

Since last year, security alerts have been sent from GitHub about Maven dependencies.
After forking this BOM project, I noticed alerts fixed in OpenAM were also occurring.
It's annoying to fix the same alert across multiple projects.

## Solution
- Move dependencies defined in multiple projects to BOM
- Use BOM in each project
- Do not overwrite the dependency version defined in BOM in each project
- If multiple versions of the same library are used, unify them to the new version

## Install/Update
Dependency effects are also occurring in other projects.
Obtain the source with modified dependencies in the following order and build
- forgerock-parent
- forgerock-bom
- forgerock-build-tools
- forgerock--i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- forgerock-bloomfilter
- opendj-sdk
- opendj
- openam

## Regression testing
There is no change in test results by test framework.
