### PR TITLE
Issue openam#302 Build fails with Maven 3.9.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
  your own identifying information:
  "Portions Copyrighted [year] [name of copyright owner]"
 
- Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+ Portions Copyrighted 2019-2025 OSSTech Corporation
  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 
@@ -384,7 +384,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.0</version>
+                    <version>3.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Analysis

openam-jp/openam#302

## Solution

Bump maven-shade-plugin version to 3.6.0.